### PR TITLE
chore:update apklib version

### DIFF
--- a/secfixes_tracker/application.cfg
+++ b/secfixes_tracker/application.cfg
@@ -13,6 +13,10 @@ SECFIXES_REPOSITORIES = {
     '3.15-community': 'https://secdb.alpinelinux.org/v3.15/community.json',
     '3.16-main': 'https://secdb.alpinelinux.org/v3.16/main.json',
     '3.16-community': 'https://secdb.alpinelinux.org/v3.16/community.json',
+    '3.17-main': 'https://secdb.alpinelinux.org/v3.17/main.json',
+    '3.17-community': 'https://secdb.alpinelinux.org/v3.17/community.json',
+    '3.18-main': 'https://secdb.alpinelinux.org/v3.18/main.json',
+    '3.18-community': 'https://secdb.alpinelinux.org/v3.18/community.json',
     'edge-main': 'https://secdb.alpinelinux.org/edge/main.json',
     'edge-community': 'https://secdb.alpinelinux.org/edge/community.json',
 }
@@ -29,8 +33,12 @@ APKINDEX_REPOSITORIES = {
     '3.15-community': 'https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz',
     '3.16-main': 'https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz',
     '3.16-community': 'https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz',
+    '3.17-main': 'https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz',
+    '3.17-community': 'https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz',
+    '3.18-main': 'https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz',
+    '3.18-community': 'https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz',
     'edge-main': 'https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz',
-    'edge-community': 'https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz',
+    'edge-community': 'https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz',
 }
 
 SECURITY_REJECTIONS = {
@@ -40,6 +48,10 @@ SECURITY_REJECTIONS = {
     '3.15-community': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/community.yaml',
     '3.16-main': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/main.yaml',
     '3.16-community': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/community.yaml',
+    '3.17-main': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/main.yaml',
+    '3.17-community': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/community.yaml',
+    '3.18-main': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/main.yaml',
+    '3.18-community': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/community.yaml',
     'edge-main': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/main.yaml',
     'edge-community': 'https://gitlab.alpinelinux.org/kaniini/security-rejections/-/raw/master/community.yaml',
 }

--- a/secfixes_tracker/version.py
+++ b/secfixes_tracker/version.py
@@ -8,7 +8,7 @@ VersionGreater = 4
 VersionFuzzy = 8
 
 
-libapk = cdll.LoadLibrary('libapk.so.3.12.0')
+libapk = cdll.LoadLibrary('libapk.so.2.14.0')
 
 
 def do_compare(ver1: str, ver2: str, ops: int):


### PR DESCRIPTION
updated libapk version to libapk.so.2.14.0, as in alpine 3.18 libapk.so.3.12.0 is not available. also updated the application.cfg files with 3.17 and 3.18 alpine versions.