### PR TITLE
ci: use ubuntu-2404-2core runner

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     name: Update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2404-2core
     container:
       image: python:3.9-alpine
     env:


### PR DESCRIPTION
When checking out a private repository, the IP is verified against the allow IP list, so we need a large runner with a static IP.

Changes
Replaced runs-on: ubuntu-24.04 with runs-on: ubuntu-2404-2core 

successful run:
https://github.com/aquasecurity/secfixes-tracker/actions/runs/24493973026