### PR TITLE
ci(cron): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 */6 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update:
     name: Update


### PR DESCRIPTION
The `cron` workflow runs the scheduled secfixes-tracker job. No GitHub API writes from the workflow, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.